### PR TITLE
Use GPU accelerated rendering

### DIFF
--- a/src/renderwindow.cpp
+++ b/src/renderwindow.cpp
@@ -16,7 +16,7 @@ RenderWindow::RenderWindow(const char* p_title, int p_w, int p_h)
 	if (window == NULL)
 		std::cout << "Failed to create SDL_Window. ERROR: " << SDL_GetError() << std::endl;
 
-	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED && SDL_RENDERER_PRESENTVSYNC);
+	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
 	gRenderer = renderer;
 	if (renderer == NULL)
 		std::cout << "Failed to create SDL_Renderer. ERROR: " << SDL_GetError() << std::endl; 


### PR DESCRIPTION
I was working on a Switch port to get more familiar with porting game to the Switch. The performance was rather bad for the game's simplicity. Turns out hardware (gpu) acceleration was not actually being used.

I though maybe you might be interested in it too.

This is a duplicate of #2, but without the accidental Switch port commits being included.